### PR TITLE
Fix validation error

### DIFF
--- a/modules/date.php
+++ b/modules/date.php
@@ -116,13 +116,11 @@ class ContactForm7Datepicker_Date {
 		$value = trim($_POST[$name]);
 
 		if ('date*' == $type && empty($value)) {
-			$result['valid'] = false;
-			$result['reason'][$name] = wpcf7_get_message('invalid_required');
+            		$result->invalidate($tag, wpcf7_get_message('invalid_required'));
 		}
 
 		if (! empty($value) && ! self::is_valid_date($value)) {
-			$result['valid'] = false;
-			$result['reason'][$name] = wpcf7_get_message('invalid_date');
+            		$result->invalidate($tag, wpcf7_get_message('invalid_date'));
 		}
 
 		return $result;

--- a/modules/datetime.php
+++ b/modules/datetime.php
@@ -121,13 +121,11 @@ class ContactForm7Datepicker_DateTime {
 		$value = trim($_POST[$name]);
 
 		if ('datetime*' == $type && empty($value)) {
-			$result['valid'] = false;
-			$result['reason'][$name] = wpcf7_get_message('invalid_required');
+            		$result->invalidate($tag, wpcf7_get_message('invalid_required'));
 		}
 
 		if (! empty($value) && ! self::is_valid_date($value)) {
-			$result['valid'] = false;
-			$result['reason'][$name] = wpcf7_get_message('invalid_datetime');
+            		$result->invalidate($tag, wpcf7_get_message('invalid_datetime'));
 		}
 
 		return $result;

--- a/modules/time.php
+++ b/modules/time.php
@@ -116,13 +116,11 @@ class ContactForm7Datepicker_Time {
 		$value = trim($_POST[$name]);
 
 		if ('time*' == $type && empty($value)) {
-			$result['valid'] = false;
-			$result['reason'][$name] = wpcf7_get_message('invalid_required');
+            		$result->invalidate($tag, wpcf7_get_message('invalid_required'));
 		}
 
 		if (! empty($value) && ! self::is_valid_date($value)) {
-			$result['valid'] = false;
-			$result['reason'][$name] = wpcf7_get_message('invalid_time');
+            		$result->invalidate($tag, wpcf7_get_message('invalid_time'));
 		}
 
 		return $result;


### PR DESCRIPTION
Datetime fields throw a PHP Notice if a field is required and empty:
`Notice:  Indirect modification of overloaded element of WPCF7_Validation has no effect in /www/htdocs/wp-content/plugins/contact-form-7-datepicker/modules/date.php on line 120`

Also the field is not marked as invalid, because CF7 changed their validation method in the past.
This change most likely breaks backwards compability with older CF7 versions, have not tested.