### PR TITLE
Compatibility with CF7 4.6, replace deprecated calls

### DIFF
--- a/modules/date.php
+++ b/modules/date.php
@@ -29,7 +29,7 @@ class ContactForm7Datepicker_Date {
 	}
 
 	public static function shortcode_handler($tag) {
-		$tag = new WPCF7_Shortcode($tag);
+		$tag = new WPCF7_FormTag($tag);
 
 		if (empty($tag->name))
 			return '';
@@ -145,8 +145,8 @@ class ContactForm7Datepicker_Date {
 	public static function add_shortcodes() {
 		if (function_exists('wpcf7_add_form_tag')) {
             // Remove Contact Form 7's date module
-            wpcf7_remove_shortcode('date');
-            wpcf7_remove_shortcode('date*');
+            wpcf7_remove_form_tag('date');
+            wpcf7_remove_form_tag('date*');
 
 			wpcf7_add_form_tag(array('date', 'date*'), array(__CLASS__, 'shortcode_handler'), true);
 		}

--- a/modules/datetime.php
+++ b/modules/datetime.php
@@ -23,7 +23,7 @@ class ContactForm7Datepicker_DateTime {
 	}
 
 	public static function shortcode_handler($tag) {
-		$tag = new WPCF7_Shortcode($tag);
+		$tag = new WPCF7_FormTag($tag);
 
 		if (empty($tag->name))
 			return '';

--- a/modules/time.php
+++ b/modules/time.php
@@ -24,7 +24,7 @@ class ContactForm7Datepicker_Time {
 	}
 
 	public static function shortcode_handler($tag) {
-		$tag = new WPCF7_Shortcode($tag);
+		$tag = new WPCF7_FormTag($tag);
 
 		if (empty($tag->name))
 			return '';

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Plugin Name ===
-Contributors: shockware, baden03, szepe.viktor, xsonic, sanidm, imelgrat
+Contributors: shockware, baden03, szepe.viktor, xsonic, sanidm, imelgrat, bmarshall511
 Tags: wordpress, datepicker, timepicker, date, time, calendar, contact form 7, forms, jqueryui
 Requires at least: 3.6.1
-Tested up to: 4.7.1
-Stable tag: 2.6.0
+Tested up to: 4.7.2
+Stable tag: 2.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,6 +32,9 @@ You can [open an issue on github](https://github.com/relu/contact-form-7-datepic
 3. Date field generator
 
 == Changelog ==
+
+= 2.6.1 =
+* Compatibility with CF7 4.6, replace deprecated calls (bmarshall511)
 
 = 2.6.0 =
 * Compatibility with CF7 4.6, replace deprecated calls (imelgrat)


### PR DESCRIPTION
Fixes a PHP notice for the deprecated functions:

- WPCF7_Shortcode
- wpcf7_remove_shortcode